### PR TITLE
Add MCP server implementation for Fivetran

### DIFF
--- a/src/fivetran_mcp/fivetran_api.py
+++ b/src/fivetran_mcp/fivetran_api.py
@@ -182,6 +182,29 @@ class FivetranClient:
             f"/v1/connections/{connection_id}/schemas/reload",
         )
 
+    async def get_table_metadata(
+        self, connection_id: str, limit: int = 1000, cursor: str | None = None
+    ) -> dict[str, Any]:
+        """Retrieve table metadata for a connection from Fivetran's Metadata API.
+
+        Returns metadata for tables that have been successfully synced, including
+        source and destination names. Note: Metadata is only available after
+        a successful sync.
+
+        Args:
+            connection_id: The connection identifier
+            limit: Maximum number of tables to return (1-1000, default 1000)
+            cursor: Optional pagination cursor
+
+        Returns:
+            Dictionary containing table metadata with source/destination mappings
+        """
+        return await self._request(
+            "GET",
+            f"/v1/metadata/connectors/{connection_id}/tables",
+            params=_pagination_params(limit, cursor),
+        )
+
     async def _request(
         self,
         method: str,


### PR DESCRIPTION
Add new tool to retrieve per-table sync status for Fivetran connections. This addresses issue #8 by providing visibility into individual tables for large connectors (e.g., Airtable with 20+ bases or Postgres with 50+ tables).

Features:
- Returns enabled/disabled state for each table
- Shows sync mode configuration
- Includes destination name metadata when available
- Supports schema filtering and enabled-only filtering
- Provides summary statistics (total, enabled, disabled counts)

Use cases:
- Identify which specific tables are configured for sync
- Debug partial sync failures in large connectors
- Monitor data freshness at the table level

Closes #8

## Summary
<!-- Brief description of changes -->

## Changes
<!-- List the specific changes made -->
-

## Files Modified
<!-- List files changed with brief description -->
| File | Change |
|------|--------|
| `src/fivetran_mcp/client.py` | |
| `src/fivetran_mcp/server.py` | |

## New Tools Added
<!-- If adding new MCP tools, list them -->
| Tool | Description |
|------|-------------|
| | |

## Fivetran API Endpoints Used
<!-- List any new API endpoints this PR uses -->
- `GET /v1/...`
- `POST /v1/...`

## Testing
<!-- How were these changes tested? -->
```bash
# Commands used to test
```

## Checklist
- [ ] Added API method to `client.py`
- [ ] Added tool with `@mcp.tool` decorator to `server.py`
- [ ] Added docstring with Args and Returns
- [ ] Updated README tool table (if new tool)
- [ ] Tested with Fivetran API
